### PR TITLE
Add `Deserialize` implementation for `Bytes`

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,18 +7,26 @@ use serde_test::{assert_tokens, assert_ser_tokens, assert_de_tokens, Token};
 #[test]
 fn test_bytes() {
     let empty = Bytes::new(&[]);
+    assert_tokens(&empty, &[Token::BorrowedBytes(b"")]);
     assert_ser_tokens(&empty, &[Token::Bytes(b"")]);
+    assert_ser_tokens(&empty, &[Token::ByteBuf(b"")]);
+    assert_de_tokens(&empty, &[Token::BorrowedStr("")]);
 
     let buf = vec![65, 66, 67];
     let bytes = Bytes::new(&buf);
+    assert_tokens(&bytes, &[Token::BorrowedBytes(b"ABC")]);
     assert_ser_tokens(&bytes, &[Token::Bytes(b"ABC")]);
+    assert_ser_tokens(&bytes, &[Token::ByteBuf(b"ABC")]);
+    assert_de_tokens(&bytes, &[Token::BorrowedStr("ABC")]);
 }
 
 #[test]
 fn test_byte_buf() {
     let empty = ByteBuf::new();
+    assert_tokens(&empty, &[Token::BorrowedBytes(b"")]);
     assert_tokens(&empty, &[Token::Bytes(b"")]);
-    assert_de_tokens(&empty, &[Token::ByteBuf(b"")]);
+    assert_tokens(&empty, &[Token::ByteBuf(b"")]);
+    assert_de_tokens(&empty, &[Token::BorrowedStr("")]);
     assert_de_tokens(&empty, &[Token::Str("")]);
     assert_de_tokens(&empty, &[Token::String("")]);
     assert_de_tokens(&empty, &[
@@ -31,8 +39,10 @@ fn test_byte_buf() {
     ]);
 
     let buf = ByteBuf::from(vec![65, 66, 67]);
+    assert_tokens(&buf, &[Token::BorrowedBytes(b"ABC")]);
     assert_tokens(&buf, &[Token::Bytes(b"ABC")]);
-    assert_de_tokens(&buf, &[Token::ByteBuf(b"ABC")]);
+    assert_tokens(&buf, &[Token::ByteBuf(b"ABC")]);
+    assert_de_tokens(&buf, &[Token::BorrowedStr("ABC")]);
     assert_de_tokens(&buf, &[Token::Str("ABC")]);
     assert_de_tokens(&buf, &[Token::String("ABC")]);
     assert_de_tokens(&buf, &[


### PR DESCRIPTION
The `Bytes` instance borrows directly from the input source and as such provides a zero-copy interface.