### PR TITLE
Remove unstable feature attribute for alloc crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 
 #![doc(html_root_url = "https://docs.rs/serde_bytes/0.11.1")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "alloc", feature(alloc))]
 #![deny(missing_docs)]
 
 mod bytes;


### PR DESCRIPTION
This crate has been very helpful in one of my projects, thanks a lot!

I noticed it needs nightly Rust because of the feature for the alloc crate. Since alloc has been [stabilized in 1.36.0](https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html#the-alloc-crate-is-stable
) for library crates, this is no longer necessary and removing it allows the library to be compiled in projects with stable Rust.