### PR TITLE
WIP: Add support for heapless::Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ std = ["serde/std"]
 alloc = ["serde/alloc"]
 
 [dependencies]
+heapless = {  version = "0.5.1", optional = true }
 serde = { version = "1.0", default-features = false }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod bytebuf;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(any(feature = "std", feature = "alloc", feature = "heapless"))]
 use serde::Deserializer;
 
 use serde::Serializer;
@@ -98,7 +98,7 @@ where
 ///     payload: Vec<u8>,
 /// }
 /// ```
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(any(feature = "std", feature = "alloc", feature= "heapless"))]
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: Deserialize<'de>,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -15,6 +15,9 @@ use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+#[cfg(feature = "heapless")]
+use heapless::{ArrayLength, Vec};
+
 /// Types that can be serialized via `#[serde(with = "serde_bytes")]`.
 pub trait Serialize {
     #[allow(missing_docs)]
@@ -34,6 +37,19 @@ impl Serialize for [u8] {
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl Serialize for Vec<u8> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self)
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<N> Serialize for Vec<u8, N>
+where
+    N: ArrayLength<u8>,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,


### PR DESCRIPTION
For embedded use cases, instead of `alloc` it's often preferable to use `heapless`: fixed-capacity strings and vectors. This patch would allow serializing `Vec<u8>` as byte strings instead of generic vectors.

A minimal example: https://github.com/nickray/serde-bytes-heapless-test/blob/master/src/lib.rs

I think it would be nice to have this patch here, would that make sense? The alternative being `heapless` having a `Bytes` type itself (https://github.com/japaric/heapless/issues/138).

Regarding tests, I'm not sure how they could be added.

Regarding error handling, I'm not sure if or how to map capacity errors when deserializing instead of horribly panicking.