### PR TITLE
Implement Deserialize/Serialize for Option

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -103,3 +103,16 @@ impl<'de> Deserialize<'de> for Box<Bytes> {
         Ok(bytes.into())
     }
 }
+
+impl<'de, T> Deserialize<'de> for Option<T>
+where
+    T: Deserialize<'de> + serde::de::Deserialize<'de> + From<&'de [u8]>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: Option<&[u8]> = serde::Deserialize::deserialize(deserializer)?;
+        Ok(bytes.map(|v| v.into()))
+    }
+}

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -105,3 +105,15 @@ where
         (**self).serialize(serializer)
     }
 }
+
+impl<T> Serialize for Option<T> where T: Serialize + std::ops::Deref<Target = [u8]> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Some(b) => serializer.serialize_some(Bytes::new(&b)),
+            None => serializer.serialize_none(),
+        }
+    }
+}

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -28,6 +28,15 @@ struct Test<'a> {
 
     #[serde(with = "serde_bytes")]
     boxed_bytes: Box<Bytes>,
+
+    #[serde(with = "serde_bytes")]
+    opt_slice: Option<&'a [u8]>,
+
+    #[serde(with = "serde_bytes")]
+    opt_vec: Option<Vec<u8>>,
+
+    #[serde(with = "serde_bytes")]
+    opt_cow_slice: Option<Cow<'a, [u8]>>,
 }
 
 #[derive(Serialize)]
@@ -47,6 +56,9 @@ fn test() {
         cow_bytes: Cow::Borrowed(Bytes::new(b"...")),
         boxed_slice: b"...".to_vec().into_boxed_slice(),
         boxed_bytes: ByteBuf::from(b"...".as_ref()).into_boxed_bytes(),
+        opt_slice: Some(b"..."),
+        opt_vec: Some(b"...".to_vec()),
+        opt_cow_slice: Some(Cow::Borrowed(b"...")),
     };
 
     assert_tokens(
@@ -54,7 +66,7 @@ fn test() {
         &[
             Token::Struct {
                 name: "Test",
-                len: 8,
+                len: 11,
             },
             Token::Str("slice"),
             Token::BorrowedBytes(b"..."),
@@ -72,6 +84,15 @@ fn test() {
             Token::Bytes(b"..."),
             Token::Str("boxed_bytes"),
             Token::Bytes(b"..."),
+            Token::Str("opt_slice"),
+            Token::Some,
+            Token::BorrowedBytes(b"..."),
+            Token::Str("opt_vec"),
+            Token::Some,
+            Token::BorrowedBytes(b"..."),
+            Token::Str("opt_cow_slice"),
+            Token::Some,
+            Token::BorrowedBytes(b"..."),
             Token::StructEnd,
         ],
     );

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -57,3 +57,11 @@ fn test_byte_buf() {
         ],
     );
 }
+
+#[test]
+fn test_option() {
+    let some = Some(Bytes::new(b"ABC"));
+    assert_tokens(&some, &[Token::Some, Token::BorrowedBytes(b"ABC")]);
+    let none: Option<ByteBuf> = None;
+    assert_tokens(&none, &[Token::None]);
+}


### PR DESCRIPTION
It'd be nice if I could handle `Option<&'a [u8]>` directly through `#[serde(with = "serde_bytes")]`.