### PR TITLE
Improve some `crate::de::Deserialize` impls by privately introducing `CowBytes<'a>`

### DIFF
--- a/src/cowbytes.rs
+++ b/src/cowbytes.rs
@@ -1,7 +1,20 @@
 use crate::{ByteBuf, Bytes};
 
-use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use core::fmt;
+
+#[cfg(feature = "alloc")]
+use alloc::borrow::Cow;
+#[cfg(all(feature = "std", not(feature = "alloc")))]
 use std::borrow::Cow;
+
+#[cfg(feature = "alloc")]
+use alloc::borrow::ToOwned;
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 pub struct CowBytes<'a> {
     bytes: Cow<'a, [u8]>,
@@ -34,7 +47,7 @@ struct CowBytesVisitor;
 impl<'de> Visitor<'de> for CowBytesVisitor {
     type Value = CowBytes<'de>;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("bytes")
     }
 

--- a/src/cowbytes.rs
+++ b/src/cowbytes.rs
@@ -1,0 +1,117 @@
+use crate::{ByteBuf, Bytes};
+
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
+
+pub struct CowBytes<'a> {
+    bytes: Cow<'a, [u8]>,
+}
+
+impl<'a> CowBytes<'a> {
+    pub fn from<I>(bytes: I) -> Self
+    where
+        I: Into<Cow<'a, [u8]>>,
+    {
+        Self {
+            bytes: bytes.into(),
+        }
+    }
+
+    pub fn into_cow(self) -> Cow<'a, [u8]> {
+        self.bytes
+    }
+
+    pub fn into_cow_bytes(self) -> Cow<'a, Bytes> {
+        match self.bytes {
+            Cow::Borrowed(bytes) => Cow::Borrowed(Bytes::new(bytes)),
+            Cow::Owned(buf) => Cow::Owned(ByteBuf::from(buf)),
+        }
+    }
+}
+
+struct CowBytesVisitor;
+
+impl<'de> Visitor<'de> for CowBytesVisitor {
+    type Value = CowBytes<'de>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("bytes")
+    }
+
+    fn visit_bytes<E>(self, bytes: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(CowBytes::from(bytes.to_owned()))
+    }
+
+    fn visit_borrowed_bytes<E>(self, bytes: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(CowBytes::from(bytes))
+    }
+
+    fn visit_byte_buf<E>(self, buf: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(CowBytes::from(buf))
+    }
+
+    fn visit_str<E>(self, str: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(CowBytes::from(str.as_bytes().to_owned()))
+    }
+
+    fn visit_borrowed_str<E>(self, str: &'de str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(CowBytes::from(str.as_bytes()))
+    }
+
+    fn visit_string<E>(self, string: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(CowBytes::from(string.into_bytes()))
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut buf: Vec<u8> = if let Some(length) = seq.size_hint() {
+            Vec::with_capacity(length)
+        } else {
+            Vec::new()
+        };
+
+        while let Some(byte) = seq.next_element()? {
+            buf.push(byte)
+        }
+
+        Ok(CowBytes::from(buf))
+    }
+}
+
+impl<'a, 'de: 'a> Deserialize<'de> for CowBytes<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(CowBytesVisitor)
+    }
+}
+
+impl Serialize for CowBytes<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.bytes)
+    }
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -7,6 +7,9 @@ use serde::Deserializer;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::ByteBuf;
 
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::cowbytes::CowBytes;
+
 #[cfg(feature = "alloc")]
 use alloc::borrow::Cow;
 #[cfg(all(feature = "std", not(feature = "alloc")))]
@@ -72,7 +75,17 @@ impl<'de: 'a, 'a> Deserialize<'de> for Cow<'a, [u8]> {
     where
         D: Deserializer<'de>,
     {
-        Deserialize::deserialize(deserializer).map(Cow::Borrowed)
+        Deserialize::deserialize(deserializer).map(CowBytes::into_cow)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<'de: 'a, 'a> Deserialize<'de> for CowBytes<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        serde::Deserialize::deserialize(deserializer)
     }
 }
 
@@ -82,7 +95,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for Cow<'a, Bytes> {
     where
         D: Deserializer<'de>,
     {
-        Deserialize::deserialize(deserializer).map(Cow::Borrowed)
+        Deserialize::deserialize(deserializer).map(CowBytes::into_cow_bytes)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ mod ser;
 #[cfg(any(feature = "std", feature = "alloc"))]
 mod bytebuf;
 
+#[cfg(any(feature = "std", feature = "alloc"))]
+mod cowbytes;
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 


### PR DESCRIPTION
Resolves #23

Notably, `CowBytes<'a>` is not publicly visible because it isn't re-exported at the crate-level like the other structs.

Follow-up work would be to add proper trait impls and documentation and make the type public.

I haven't bothered to learn `serde_test` and as such this introduces some untested code in the `cowbytes.rs` module. If that would block this PR I am happy to learn it and add the relevant tests.