### PR TITLE
Allow Cow<[u8]> to deserialize to owned bytes

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -7,6 +7,9 @@ use serde::Deserializer;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::ByteBuf;
 
+#[cfg(any(feature = "std", feature = "alloc"))]
+use core::cmp;
+
 #[cfg(feature = "alloc")]
 use alloc::borrow::Cow;
 #[cfg(all(feature = "std", not(feature = "alloc")))]
@@ -14,9 +17,13 @@ use std::borrow::Cow;
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-
+#[cfg(feature = "alloc")]
+use alloc::string::String;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+use serde::de::SeqAccess;
 
 /// Types that can be deserialized via `#[serde(with = "serde_bytes")]`.
 pub trait Deserialize<'de>: Sized {
@@ -72,7 +79,73 @@ impl<'de: 'a, 'a> Deserialize<'de> for Cow<'a, [u8]> {
     where
         D: Deserializer<'de>,
     {
-        Deserialize::deserialize(deserializer).map(Cow::Borrowed)
+        struct CowVisitor;
+
+        impl<'de> Visitor<'de> for CowVisitor {
+            type Value = Cow<'de, [u8]>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a byte array")
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(Cow::Borrowed(v))
+            }
+
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(Cow::Borrowed(v.as_bytes()))
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(Cow::Owned(v.to_vec()))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(Cow::Owned(v.as_bytes().to_vec()))
+            }
+
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(Cow::Owned(v))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(Cow::Owned(v.into_bytes()))
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let len = cmp::min(visitor.size_hint().unwrap_or(0), 4096);
+                let mut bytes = Vec::with_capacity(len);
+
+                while let Some(b) = visitor.next_element()? {
+                    bytes.push(b);
+                }
+
+                Ok(Cow::Owned(bytes))
+            }
+        }
+
+        deserializer.deserialize_bytes(CowVisitor)
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -155,7 +155,11 @@ impl<'de: 'a, 'a> Deserialize<'de> for Cow<'a, Bytes> {
     where
         D: Deserializer<'de>,
     {
-        Deserialize::deserialize(deserializer).map(Cow::Borrowed)
+        let cow: Cow<[u8]> = Deserialize::deserialize(deserializer)?;
+        match cow {
+            Cow::Borrowed(bytes) => Ok(Cow::Borrowed(Bytes::new(bytes))),
+            Cow::Owned(bytes) => Ok(Cow::Owned(ByteBuf::from(bytes))),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #23. Closes #24.