### PR TITLE
Add support for `[u8; N]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 keywords = ["serde", "serialization", "no_std", "bytes"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/serde-rs/bytes"
-rust-version = "1.31"
+rust-version = "1.53"
 
 [features]
 default = ["std"]

--- a/src/bytearray.rs
+++ b/src/bytearray.rs
@@ -1,0 +1,225 @@
+use crate::Bytes;
+use core::borrow::{Borrow, BorrowMut};
+use core::cmp::Ordering;
+use core::convert::TryInto;
+use core::fmt::{self, Debug};
+use core::hash::{Hash, Hasher};
+use core::ops::{Deref, DerefMut};
+
+use serde::de::{Deserialize, Deserializer, Error, SeqAccess, Visitor};
+use serde::ser::{Serialize, Serializer};
+
+/// Wrapper around `[u8; N]` to serialize and deserialize efficiently.
+///
+/// ```
+/// use std::collections::HashMap;
+/// use std::io;
+///
+/// use serde_bytes::ByteArray;
+///
+/// fn deserialize_bytearrays() -> bincode::Result<()> {
+///     let example_data = [
+///         2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 116,
+///         119, 111, 1, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 111, 110, 101
+///     ];
+///
+///     let map: HashMap<u32, ByteArray<3>> = bincode::deserialize(&example_data[..])?;
+///
+///     println!("{:?}", map);
+///
+///     Ok(())
+/// }
+/// #
+/// # fn main() {
+/// #     deserialize_bytearrays().unwrap();
+/// # }
+/// ```
+#[derive(Clone, Eq, Ord)]
+pub struct ByteArray<const N: usize> {
+    bytes: [u8; N],
+}
+
+impl<const N: usize> ByteArray<N> {
+    /// Transform an [array](https://doc.rust-lang.org/stable/std/primitive.array.html) to the equivalent `ByteArray`
+    pub fn new(bytes: [u8; N]) -> Self {
+        Self { bytes }
+    }
+
+    /// Wrap existing bytes into a `ByteArray`
+    pub fn from<T: Into<[u8; N]>>(bytes: T) -> Self {
+        Self {
+            bytes: bytes.into(),
+        }
+    }
+
+    /// Unwraps the byte array underlying this `ByteArray`
+    pub fn into_array(self) -> [u8; N] {
+        self.bytes
+    }
+}
+
+impl<const N: usize> Debug for ByteArray<N> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(&self.bytes, f)
+    }
+}
+
+impl<const N: usize> AsRef<[u8; N]> for ByteArray<N> {
+    fn as_ref(&self) -> &[u8; N] {
+        &self.bytes
+    }
+}
+impl<const N: usize> AsMut<[u8; N]> for ByteArray<N> {
+    fn as_mut(&mut self) -> &mut [u8; N] {
+        &mut self.bytes
+    }
+}
+
+impl<const N: usize> Borrow<[u8; N]> for ByteArray<N> {
+    fn borrow(&self) -> &[u8; N] {
+        &self.bytes
+    }
+}
+impl<const N: usize> BorrowMut<[u8; N]> for ByteArray<N> {
+    fn borrow_mut(&mut self) -> &mut [u8; N] {
+        &mut self.bytes
+    }
+}
+
+impl<const N: usize> Deref for ByteArray<N> {
+    type Target = [u8; N];
+
+    fn deref(&self) -> &Self::Target {
+        &self.bytes
+    }
+}
+
+impl<const N: usize> DerefMut for ByteArray<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.bytes
+    }
+}
+
+impl<const N: usize> Borrow<Bytes> for ByteArray<N> {
+    fn borrow(&self) -> &Bytes {
+        Bytes::new(&self.bytes)
+    }
+}
+
+impl<const N: usize> BorrowMut<Bytes> for ByteArray<N> {
+    fn borrow_mut(&mut self) -> &mut Bytes {
+        unsafe { &mut *(&mut self.bytes as &mut [u8] as *mut [u8] as *mut Bytes) }
+    }
+}
+
+impl<Rhs, const N: usize> PartialEq<Rhs> for ByteArray<N>
+where
+    Rhs: ?Sized + Borrow<[u8; N]>,
+{
+    fn eq(&self, other: &Rhs) -> bool {
+        self.as_ref().eq(other.borrow())
+    }
+}
+
+impl<Rhs, const N: usize> PartialOrd<Rhs> for ByteArray<N>
+where
+    Rhs: ?Sized + Borrow<[u8; N]>,
+{
+    fn partial_cmp(&self, other: &Rhs) -> Option<Ordering> {
+        self.as_ref().partial_cmp(other.borrow())
+    }
+}
+
+impl<const N: usize> Hash for ByteArray<N> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.bytes.hash(state);
+    }
+}
+
+impl<const N: usize> IntoIterator for ByteArray<N> {
+    type Item = u8;
+    type IntoIter = <[u8; N] as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIterator::into_iter(self.bytes)
+    }
+}
+
+impl<'a, const N: usize> IntoIterator for &'a ByteArray<N> {
+    type Item = &'a u8;
+    type IntoIter = <&'a [u8; N] as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.bytes.iter()
+    }
+}
+
+impl<'a, const N: usize> IntoIterator for &'a mut ByteArray<N> {
+    type Item = &'a mut u8;
+    type IntoIter = <&'a mut [u8; N] as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.bytes.iter_mut()
+    }
+}
+
+impl<const N: usize> Serialize for ByteArray<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.bytes)
+    }
+}
+
+struct ByteArrayVisitor<const N: usize>;
+
+impl<'de, const N: usize> Visitor<'de> for ByteArrayVisitor<N> {
+    type Value = ByteArray<N>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a byte array of length {}", N)
+    }
+
+    fn visit_seq<V>(self, mut seq: V) -> Result<ByteArray<N>, V::Error>
+    where
+        V: SeqAccess<'de>,
+    {
+        let mut bytes = [0; N];
+
+        for (idx, byte) in bytes.iter_mut().enumerate() {
+            *byte = seq
+                .next_element()?
+                .ok_or_else(|| V::Error::invalid_length(idx, &self))?;
+        }
+
+        Ok(ByteArray::from(bytes))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<ByteArray<N>, E>
+    where
+        E: Error,
+    {
+        Ok(ByteArray {
+            bytes: v
+                .try_into()
+                .map_err(|_| E::invalid_length(v.len(), &self))?,
+        })
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<ByteArray<N>, E>
+    where
+        E: Error,
+    {
+        self.visit_bytes(v.as_bytes())
+    }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for ByteArray<N> {
+    fn deserialize<D>(deserializer: D) -> Result<ByteArray<N>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(ByteArrayVisitor::<N>)
+    }
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,4 +1,4 @@
-use crate::Bytes;
+use crate::{ByteArray, Bytes};
 use core::fmt;
 use core::marker::PhantomData;
 use serde::de::{Error, Visitor};
@@ -60,6 +60,26 @@ impl<'de: 'a, 'a> Deserialize<'de> for &'a Bytes {
     {
         // serde::Deserialize for &[u8] is already optimized, so simply forward to that.
         serde::Deserialize::deserialize(deserializer).map(Bytes::new)
+    }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for [u8; N] {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let arr: ByteArray<N> = serde::Deserialize::deserialize(deserializer)?;
+        Ok(*arr)
+    }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for ByteArray<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Via the serde::Deserialize impl for ByteArray
+        serde::Deserialize::deserialize(deserializer)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,9 @@ pub use crate::bytebuf::ByteBuf;
 ///
 ///     #[serde(with = "serde_bytes")]
 ///     byte_buf: Vec<u8>,
+///
+///     #[serde(with = "serde_bytes")]
+///     byte_array: [u8; 314],
 /// }
 /// ```
 pub fn serialize<T, S>(bytes: &T, serializer: S) -> Result<S::Ok, S::Error>
@@ -106,6 +109,9 @@ where
 /// struct Packet {
 ///     #[serde(with = "serde_bytes")]
 ///     payload: Vec<u8>,
+///
+///     #[serde(with = "serde_bytes")]
+///     byte_array: [u8; 314],
 /// }
 /// ```
 #[cfg(any(feature = "std", feature = "alloc"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@
 //!
 //!     #[serde(with = "serde_bytes")]
 //!     byte_buf: Vec<u8>,
+//!
+//!     #[serde(with = "serde_bytes")]
+//!     byte_array: [u8; 314],
 //! }
 //! ```
 
@@ -36,6 +39,7 @@
     clippy::needless_doctest_main
 )]
 
+mod bytearray;
 mod bytes;
 mod de;
 mod ser;
@@ -51,6 +55,7 @@ use serde::Deserializer;
 
 use serde::Serializer;
 
+pub use crate::bytearray::ByteArray;
 pub use crate::bytes::Bytes;
 pub use crate::de::Deserialize;
 pub use crate::ser::Serialize;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,4 +1,4 @@
-use crate::Bytes;
+use crate::{ByteArray, Bytes};
 use serde::Serializer;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -48,6 +48,24 @@ impl Serialize for Bytes {
         S: Serializer,
     {
         serializer.serialize_bytes(self)
+    }
+}
+
+impl<const N: usize> Serialize for [u8; N] {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self)
+    }
+}
+
+impl<const N: usize> Serialize for ByteArray<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&**self)
     }
 }
 

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::derive_partial_eq_without_eq, clippy::ref_option_ref)]
 
-use serde_bytes::{ByteBuf, Bytes};
+use serde_bytes::{ByteArray, ByteBuf, Bytes};
 use serde_derive::{Deserialize, Serialize};
 use serde_test::{assert_tokens, Token};
 use std::borrow::Cow;
@@ -11,10 +11,16 @@ struct Test<'a> {
     slice: &'a [u8],
 
     #[serde(with = "serde_bytes")]
+    array: [u8; 314],
+
+    #[serde(with = "serde_bytes")]
     vec: Vec<u8>,
 
     #[serde(with = "serde_bytes")]
     bytes: &'a Bytes,
+
+    #[serde(with = "serde_bytes")]
+    byte_array: ByteArray<314>,
 
     #[serde(with = "serde_bytes")]
     byte_buf: ByteBuf,
@@ -38,6 +44,12 @@ struct Test<'a> {
     opt_vec: Option<Vec<u8>>,
 
     #[serde(with = "serde_bytes")]
+    opt_array: Option<[u8; 314]>,
+
+    #[serde(with = "serde_bytes")]
+    opt_bytearray: Option<ByteArray<314>>,
+
+    #[serde(with = "serde_bytes")]
     opt_cow_slice: Option<Cow<'a, [u8]>>,
 }
 
@@ -51,8 +63,10 @@ struct Dst {
 fn test() {
     let test = Test {
         slice: b"...",
+        array: [0; 314],
         vec: b"...".to_vec(),
         bytes: Bytes::new(b"..."),
+        byte_array: ByteArray::new([0; 314]),
         byte_buf: ByteBuf::from(b"...".as_ref()),
         cow_slice: Cow::Borrowed(b"..."),
         cow_bytes: Cow::Borrowed(Bytes::new(b"...")),
@@ -60,6 +74,8 @@ fn test() {
         boxed_bytes: ByteBuf::from(b"...".as_ref()).into_boxed_bytes(),
         opt_slice: Some(b"..."),
         opt_vec: Some(b"...".to_vec()),
+        opt_array: Some([0; 314]),
+        opt_bytearray: Some(ByteArray::new([0; 314])),
         opt_cow_slice: Some(Cow::Borrowed(b"...")),
     };
 
@@ -68,14 +84,18 @@ fn test() {
         &[
             Token::Struct {
                 name: "Test",
-                len: 11,
+                len: 15,
             },
             Token::Str("slice"),
             Token::BorrowedBytes(b"..."),
+            Token::Str("array"),
+            Token::Bytes(&[0; 314]),
             Token::Str("vec"),
             Token::Bytes(b"..."),
             Token::Str("bytes"),
             Token::BorrowedBytes(b"..."),
+            Token::Str("byte_array"),
+            Token::Bytes(&[0; 314]),
             Token::Str("byte_buf"),
             Token::Bytes(b"..."),
             Token::Str("cow_slice"),
@@ -92,6 +112,12 @@ fn test() {
             Token::Str("opt_vec"),
             Token::Some,
             Token::Bytes(b"..."),
+            Token::Str("opt_array"),
+            Token::Some,
+            Token::Bytes(&[0; 314]),
+            Token::Str("opt_bytearray"),
+            Token::Some,
+            Token::Bytes(&[0; 314]),
             Token::Str("opt_cow_slice"),
             Token::Some,
             Token::BorrowedBytes(b"..."),

--- a/tests/test_partialeq.rs
+++ b/tests/test_partialeq.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::needless_pass_by_value)]
 
-use serde_bytes::{ByteBuf, Bytes};
+use serde_bytes::{ByteArray, ByteBuf, Bytes};
 
 fn _bytes_eq_slice(bytes: &Bytes, slice: &[u8]) -> bool {
     bytes == slice
@@ -12,4 +12,12 @@ fn _bytebuf_eq_vec(bytebuf: ByteBuf, vec: Vec<u8>) -> bool {
 
 fn _bytes_eq_bytestring(bytes: &Bytes) -> bool {
     bytes == b"..."
+}
+
+fn _bytearray_eq_bytestring<const N: usize>(bytes: &ByteArray<N>) -> bool {
+    bytes == &[0u8; N]
+}
+
+fn _bytearray_eq_bytearray<const N: usize>(bytes: &ByteArray<N>, other: &ByteArray<N>) -> bool {
+    bytes == other
 }

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,4 +1,4 @@
-use serde_bytes::{ByteBuf, Bytes};
+use serde_bytes::{ByteArray, ByteBuf, Bytes};
 use serde_test::{assert_de_tokens, assert_ser_tokens, assert_tokens, Token};
 
 #[test]
@@ -56,4 +56,20 @@ fn test_byte_buf() {
             Token::SeqEnd,
         ],
     );
+}
+
+#[test]
+fn test_bytearray() {
+    let empty = ByteArray::new([]);
+    assert_tokens(&empty, &[Token::BorrowedBytes(b"")]);
+    assert_ser_tokens(&empty, &[Token::Bytes(b"")]);
+    assert_ser_tokens(&empty, &[Token::ByteBuf(b"")]);
+    assert_de_tokens(&empty, &[Token::BorrowedStr("")]);
+
+    let buf = [65, 66, 67];
+    let bytes = ByteArray::new(buf);
+    assert_tokens(&bytes, &[Token::BorrowedBytes(b"ABC")]);
+    assert_ser_tokens(&bytes, &[Token::Bytes(b"ABC")]);
+    assert_ser_tokens(&bytes, &[Token::ByteBuf(b"ABC")]);
+    assert_de_tokens(&bytes, &[Token::BorrowedStr("ABC")]);
 }


### PR DESCRIPTION
Hi.

This PR adds support for constant length byte arrays `[u8; N]` and adds a `ByteArray<const N: usize>` wrapper type similar to `BytesBuf`. This would close #26.

Motivations
========

Fixed sized array are often used for cryptography and embedded systems. Having efficient support to serialize/deserialize keys would be great. 

Parts of the PR requiring discussion
====

I'm not sure why `ByteBuf` and `Bytes` implements `PartialEq`  and `PartialOrd` for types implementing `AsRef<[u8]>` and not `Borrow<[u8]>`. ByteArray implements `PartialEq`/`Ord` with types implementing `Borrow<[u8; N]>` so that it can be compared to itself and to `[u8; N]`

It might be worth considering adding a `new_mut(&mut [u8]) -> Bytes` function to `Bytes` so that the same (unsafe) code is reused for the `BorrowMut<Bytes>` implementations of `ByteArray` and `ByteBuf`.

Drawbacks
========

Due to the use of const generics, this would require raising the MSRV to 1.53 (which could be lowered to 1.51 by removing the `IntoIterator` implementation).

Edit: Since 0504fcb86133c78a75560c907556f1d6031bdf23 already bumped MSRV to 1.56, this drawback doesn't apply anymore.
