### PR TITLE
fix: actually use optimizations for deserializing &[u8]

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -38,8 +38,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for &'a [u8] {
     where
         D: Deserializer<'de>,
     {
-        // Via the serde::Deserialize impl for &[u8].
-        serde::Deserialize::deserialize(deserializer)
+        Deserialize::deserialize(deserializer).map(Bytes::as_ref)
     }
 }
 
@@ -58,7 +57,8 @@ impl<'de: 'a, 'a> Deserialize<'de> for &'a Bytes {
     where
         D: Deserializer<'de>,
     {
-        Deserialize::deserialize(deserializer).map(Bytes::new)
+        // Via the serde::Deserialize impl for Bytes.
+        serde::Deserialize::deserialize(deserializer)
     }
 }
 


### PR DESCRIPTION
The Deserialize impl for `&[u8]` needs to forward to the specialized one for `Bytes`, not the other way around. Fixes #30.