### PR TITLE
Bytes deserialization cleanup

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -12,7 +12,7 @@ use alloc::boxed::Box;
 #[cfg(any(feature = "std", feature = "alloc"))]
 use crate::ByteBuf;
 
-use serde::de::{Deserialize, Deserializer, Error, Visitor};
+use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
 /// Wrapper around `[u8]` to serialize and deserialize efficiently.
@@ -161,35 +161,11 @@ impl Serialize for Bytes {
     }
 }
 
-struct BytesVisitor;
-
-impl<'de> Visitor<'de> for BytesVisitor {
-    type Value = &'de Bytes;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a borrowed byte array")
-    }
-
-    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(Bytes::new(v))
-    }
-
-    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(Bytes::new(v.as_bytes()))
-    }
-}
-
 impl<'a, 'de: 'a> Deserialize<'de> for &'a Bytes {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_bytes(BytesVisitor)
+        Deserialize::deserialize(deserializer).map(Bytes::new)
     }
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -166,6 +166,7 @@ impl<'a, 'de: 'a> Deserialize<'de> for &'a Bytes {
     where
         D: Deserializer<'de>,
     {
+        // serde::Deserialize for &[u8] is already optimized, so simply forward to that.
         Deserialize::deserialize(deserializer).map(Bytes::new)
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -38,7 +38,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for &'a [u8] {
     where
         D: Deserializer<'de>,
     {
-        // Via the serde::Deserialize impl for &[u8].
+        // serde::Deserialize for &[u8] is already optimized, so simply forward to that.
         serde::Deserialize::deserialize(deserializer)
     }
 }
@@ -58,6 +58,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for &'a Bytes {
     where
         D: Deserializer<'de>,
     {
+        // serde::Deserialize for &[u8] is already optimized, so simply forward to that.
         serde::Deserialize::deserialize(deserializer).map(Bytes::new)
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -58,7 +58,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for &'a Bytes {
     where
         D: Deserializer<'de>,
     {
-        Deserialize::deserialize(deserializer).map(Bytes::new)
+        serde::Deserialize::deserialize(deserializer).map(Bytes::new)
     }
 }
 


### PR DESCRIPTION
This is a followup to #30. Since vanilla `serde` already specializes the deserialization of `&[u8]`, there is no work to be done here by this crate. This PR removes the `BytesVisitor` (which is just a copy of the one in `serde`) and adds a couple comments to hopefully make the situation clearer for future readers.