### PR TITLE
Hide repr attribute from documentation

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -37,7 +37,7 @@ use serde::ser::{Serialize, Serializer};
 /// # }
 /// ```
 #[derive(Eq, Ord)]
-#[repr(transparent)]
+#[cfg_attr(not(doc), repr(transparent))]
 pub struct Bytes {
     bytes: [u8],
 }


### PR DESCRIPTION
Work around this rustdoc issue: https://github.com/rust-lang/rust/issues/90435.