### PR TITLE
Unconditional serde_bytes::deserialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,7 @@ mod bytebuf;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use serde::Deserializer;
-
-use serde::Serializer;
+use serde::{Deserializer, Serializer};
 
 pub use crate::bytearray::ByteArray;
 pub use crate::bytes::Bytes;
@@ -116,7 +113,6 @@ where
 ///     byte_array: [u8; 314],
 /// }
 /// ```
-#[cfg(any(feature = "std", feature = "alloc"))]
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: Deserialize<'de>,


### PR DESCRIPTION
This cfg is from back when `deserialize` had this signature, before https://github.com/serde-rs/bytes/commit/6a14f766ac65250424f9b85e077f2d02bf709a91, so it didn't make sense without `Vec` existing:

https://github.com/serde-rs/bytes/blob/29f7e7a3ad3b308f3b4a61849f8a3b01c7d3fc55/src/lib.rs#L131-L134