### PR TITLE
Implement deserializing &'de [u8; N]

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -73,6 +73,16 @@ impl<'de, const N: usize> Deserialize<'de> for [u8; N] {
     }
 }
 
+impl<'de, const N: usize> Deserialize<'de> for &'de [u8; N] {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let arr: &'de ByteArray<N> = serde::Deserialize::deserialize(deserializer)?;
+        Ok(&arr)
+    }
+}
+
 impl<'de, const N: usize> Deserialize<'de> for ByteArray<N> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -14,6 +14,9 @@ struct Test<'a> {
     array: [u8; 314],
 
     #[serde(with = "serde_bytes")]
+    borrowed_array: &'a [u8; 314],
+
+    #[serde(with = "serde_bytes")]
     vec: Vec<u8>,
 
     #[serde(with = "serde_bytes")]
@@ -67,6 +70,7 @@ fn test() {
     let test = Test {
         slice: b"...",
         array: [0; 314],
+        borrowed_array: &[1; 314],
         vec: b"...".to_vec(),
         bytes: Bytes::new(b"..."),
         byte_array: ByteArray::new([0; 314]),
@@ -88,12 +92,14 @@ fn test() {
         &[
             Token::Struct {
                 name: "Test",
-                len: 16,
+                len: 17,
             },
             Token::Str("slice"),
             Token::BorrowedBytes(b"..."),
             Token::Str("array"),
             Token::Bytes(&[0; 314]),
+            Token::Str("borrowed_array"),
+            Token::BorrowedBytes(&[1; 314]),
             Token::Str("vec"),
             Token::Bytes(b"..."),
             Token::Str("bytes"),


### PR DESCRIPTION
e1f53b2d4b5298763f207af2f32466a45ca14d24 (https://github.com/serde-rs/bytes/pull/46) implemented deserializing `&'de ByteArray` but not `&'de [u8; N]`