### PR TITLE
Add base64 for ByteBuf when serializer is human-readable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ alloc = ["serde/alloc"]
 
 [dependencies]
 serde = { version = "1.0.166", default-features = false }
+base64 = "0.21.4"
 
 [dev-dependencies]
 bincode = "1.3.3"


### PR DESCRIPTION
Depending on the `is_human_readable()` value for the serializer, either chooses a binary representation or base64. Implements the suggestion of https://github.com/serde-rs/bytes/issues/37 for `BytesBuf`.

Is this functionality something that you would merge? If so, I can look into extending it to the rest of the crate and adding some tests.
