### PR TITLE
make the command 'cargo test --no-default-features' work

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! # use serde_derive::{Deserialize, Serialize};
 //! use serde::{Deserialize, Serialize};
 //!
+//! # #[cfg(any(feature = "std", feature = "alloc"))]
 //! #[derive(Deserialize, Serialize)]
 //! struct Efficient<'a> {
 //!     #[serde(with = "serde_bytes")]
@@ -77,6 +78,7 @@ pub use crate::bytebuf::ByteBuf;
 /// # use serde_derive::Serialize;
 /// use serde::Serialize;
 ///
+/// # #[cfg(any(feature = "std", feature = "alloc"))]
 /// #[derive(Serialize)]
 /// struct Efficient<'a> {
 ///     #[serde(with = "serde_bytes")]
@@ -108,6 +110,7 @@ where
 /// # use serde_derive::Deserialize;
 /// use serde::Deserialize;
 ///
+/// # #[cfg(any(feature = "std", feature = "alloc"))]
 /// #[derive(Deserialize)]
 /// struct Packet {
 ///     #[serde(with = "serde_bytes")]

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::derive_partial_eq_without_eq, clippy::ref_option_ref)]
+#![cfg(any(feature = "std", feature = "alloc"))]
 
 use serde_bytes::{ByteArray, ByteBuf, Bytes};
 use serde_derive::{Deserialize, Serialize};

--- a/tests/test_partialeq.rs
+++ b/tests/test_partialeq.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::needless_pass_by_value)]
+#![cfg(any(feature = "std", feature = "alloc"))]
 
 use serde_bytes::{ByteArray, ByteBuf, Bytes};
 

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "std", feature = "alloc"))]
+
 use serde_bytes::{ByteArray, ByteBuf, Bytes};
 use serde_test::{assert_de_tokens, assert_ser_tokens, assert_tokens, Token};
 


### PR DESCRIPTION
based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/serde-bytes/debian/patches/ignore-no-default-features-tests.diff